### PR TITLE
Updated version of Docker Desktop to 2.1.0.3 

### DIFF
--- a/src/pages/installation.js
+++ b/src/pages/installation.js
@@ -212,8 +212,8 @@ class Installation extends React.Component {
             </h2>
             <h3>1. Download and Install Docker Desktop for Mac</h3>
             <p>
-              <a href="https://download.docker.com/mac/stable/31259/Docker.dmg" className="button special ">
-                    <i className="fas fa-download fa-sm"></i> Docker Desktop for Mac v2.0.0.3
+              <a href="https://download.docker.com/mac/stable/38240/Docker.dmg" className="button special ">
+                    <i className="fas fa-download fa-sm"></i> Docker Desktop for Mac v2.1.0.3
               </a>
             </p>
             <h3>2. Start Docker Desktop</h3>
@@ -313,8 +313,8 @@ class Installation extends React.Component {
             <h3>2. Download and Install Docker Desktop for Windows</h3>
             <p></p>
             <p>
-              <a href="https://download.docker.com/win/stable/31259/Docker%20for%20Windows%20Installer.exe" className="button special ">
-                    <i className="fas fa-download fa-sm"></i> Docker Desktop for Windows v2.0.0.3
+              <a href="https://download.docker.com/win/stable/38240/Docker%20Desktop%20Installer.exe" className="button special ">
+                    <i className="fas fa-download fa-sm"></i> Docker Desktop for Windows v2.1.0.3
               </a>
             </p>
             <h3>3. Configure Docker Desktop on Windows </h3>


### PR DESCRIPTION
This keeps docksal.io in sync with the versions pointed at on https://docs.docksal.io/getting-started/setup/