### PR TITLE
Update installation.js

### DIFF
--- a/src/pages/installation.js
+++ b/src/pages/installation.js
@@ -212,8 +212,8 @@ class Installation extends React.Component {
             </h2>
             <h3>1. Download and Install Docker Desktop for Mac</h3>
             <p>
-              <a href="https://download.docker.com/mac/stable/38240/Docker.dmg" className="button special ">
-                    <i className="fas fa-download fa-sm"></i> Docker Desktop for Mac v2.1.0.3
+              <a href="https://download.docker.com/mac/stable/39773/Docker.dmg" className="button special ">
+                    <i className="fas fa-download fa-sm"></i> Docker Desktop for Mac v2.1.0.4
               </a>
             </p>
             <h3>2. Start Docker Desktop</h3>


### PR DESCRIPTION
This is a PR relating to this issue which I opened:

https://github.com/docksal/docksal.io/issues/20

The Docker link/version in the install instructions should be updated to more recent and likely correct version to minimize the sort of issues people are encountering like this:

docksal/docksal#482

The getting started materials should also likely be updated:

https://docs.docksal.io/getting-started/setup/